### PR TITLE
fix config6.max_rules init

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -1685,6 +1685,7 @@ setup_lpm(int socketid)
 	/* create the LPM6 table */
 	snprintf(s, sizeof(s), "IPV6_L3FWD_LPM_%d", socketid);
 
+	config6.max_rules = IPV6_L3FWD_LPM_MAX_RULES;
 	config6.number_tbl8s = IPV6_L3FWD_LPM_NUMBER_TBL8S;
 	config6.flags = 0;
 	ipv6_pktj_lookup_struct[socketid] =


### PR DESCRIPTION
This missing initialization causes "Unable to create the pktj LPM6 table" (app/main.c:1695) error on some machines.