### PR TITLE
Make packet-journey build with DPDK-stable 17.05.2

### DIFF
--- a/app/acl.c
+++ b/app/acl.c
@@ -69,6 +69,7 @@
 #include <errno.h>
 #include <getopt.h>
 
+#include <rte_version.h>
 #include <rte_common.h>
 #include <rte_byteorder.h>
 #include <rte_log.h>

--- a/app/acl.h
+++ b/app/acl.h
@@ -74,7 +74,7 @@ extern struct acl_parm acl_parm_config;
 extern struct rte_acl_ctx* ipv4_acx[NB_SOCKETS];
 extern struct rte_acl_ctx* ipv6_acx[NB_SOCKETS];
 
-#if RTE_VER_MINOR > 1 && RTE_VER_MAJOR == 2
+#if RTE_VER_MONTH > 1 && RTE_VER_YEAR == 2
 /*
  * That effectively defines order of IPV4VLAN classifications:
  *  - PROTO

--- a/app/cmdline.c
+++ b/app/cmdline.c
@@ -73,6 +73,7 @@
 #include <poll.h>
 #include <signal.h>
 
+#include <rte_version.h>
 #include <rte_common.h>
 #include <rte_log.h>
 #include <rte_lcore.h>
@@ -190,7 +191,11 @@ cmd_loglevel_parsed(void* parsed_result,
 		    __rte_unused void* data)
 {
 	struct cmd_loglevel_result* res = parsed_result;
+#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
 	rte_log_set_global_level(res->level);
+#else
+	rte_set_log_level(res->level);
+#endif
 }
 
 cmdline_parse_token_string_t cmd_loglevel_loglevel =
@@ -221,7 +226,11 @@ cmd_logtype_parsed(void* parsed_result,
 		   __rte_unused void* data)
 {
 	struct cmd_logtype_result* res = parsed_result;
+#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
 	rte_log_set_level(res->type, res->enable ? RTE_LOG_DEBUG : 0);
+#else
+	rte_set_log_type(res->type, res->enable);
+#endif
 }
 
 cmdline_parse_token_string_t cmd_logtype_logtype =

--- a/app/cmdline_helpers.c
+++ b/app/cmdline_helpers.c
@@ -58,6 +58,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <rte_version.h>
 #include <rte_common.h>
 #include <rte_byteorder.h>
 #include <rte_debug.h>

--- a/app/common.h
+++ b/app/common.h
@@ -102,10 +102,14 @@ extern struct lpm_stats_t lpm6_stats[NB_SOCKETS];
 
 typedef uint8_t portid_t;
 
+#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+typedef uint32_t lpm6_neigh;
+#else
 #ifdef LPM6_16BIT
 typedef uint16_t lpm6_neigh;
 #else
 typedef uint8_t lpm6_neigh;
+#endif
 #endif
 
 #endif

--- a/app/config.c
+++ b/app/config.c
@@ -66,6 +66,7 @@
 #include <string.h>
 #include <getopt.h>
 
+#include <rte_version.h>
 #include <rte_string_fns.h>
 #include <rte_mempool.h>
 #include <rte_ethdev.h>

--- a/app/control.c
+++ b/app/control.c
@@ -65,6 +65,7 @@
 #include <arpa/inet.h>
 #include <spawn.h>
 
+#include <rte_version.h>
 #include <rte_common.h>
 #include <rte_malloc.h>
 #include <rte_log.h>

--- a/app/kni.c
+++ b/app/kni.c
@@ -76,6 +76,7 @@
 #include <unistd.h>
 #include <signal.h>
 
+#include <rte_version.h>
 #include <rte_common.h>
 #include <rte_log.h>
 #include <rte_memory.h>

--- a/app/main.c
+++ b/app/main.c
@@ -75,6 +75,7 @@
 #include <sys/prctl.h>
 #include <unistd.h>
 
+#include <rte_version.h>
 #include <rte_common.h>
 #include <rte_vect.h>
 #include <rte_byteorder.h>


### PR DESCRIPTION
This series of patches make packet-journey build against dpdk-stable 17.05.2 and hopefully make it easier to adapt to future DPDK changes.
